### PR TITLE
test: pin vbs test corpus and exclude/skip new failing scripts

### DIFF
--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1025,6 +1025,14 @@ static EXCLUDED_FILES: &[&str] = &[
     "sverrewl-vpxtable-scripts/Theatre of magic VPX NZ-TT 1.0.vbs",
     // Uses `If ... End If` without Then TODO check if this is valid
     "sverrewl-vpxtable-scripts/Bally Roller Derby 2.0.vbs",
+    // Malformed: a stray backtick is used as a comment marker (rejected by wine vbscript).
+    "vpx-standalone-scripts/KISS (Stern 2015)/KISS (Stern 2015).vbs",
+    // TODO valid VBScript, temporarily excluded until the lexer supports them:
+    // bracketed (escaped) identifiers like `[L178 Side Flasher]`.
+    "sverrewl-vpxtable-scripts/No Good Gofers(Williams 1997)V1.1.2.vbs",
+    // TODO valid VBScript, temporarily excluded until the lexer supports them:
+    // octal literals (`&O17`), wide hex (`&h000000000`) and date literals with day 13-31.
+    "wine-vbscript/dlls/vbscript/tests/lang.vbs",
 ];
 
 /// It tries to tokenize all `.vbs` files going one level lower from the root of the project.
@@ -1079,6 +1087,10 @@ fn try_parsing_all_vbs_files() {
     for path in paths {
         // see https://github.com/sverrewl/vpxtable_scripts/issues/30 (X-Men)
         // see https://github.com/sverrewl/vpxtable_scripts/issues/31 (Kessel Run / Tiki)
+        // All malformed, rejected by wine vbscript:
+        // - Pinball and Nitro Ground Shaker hf5: `bsSaucer1..KickForceVar` double dot.
+        // - Robo-War: the `Bumper*_Hit` subs call `SoundFX("Bumper", ActiveBall, 1`
+        //   with the closing parenthesis missing.
         if path.to_string_lossy().contains("X-Men(ICPjuggla)6-27c.vbs")
             || path
                 .to_string_lossy()
@@ -1089,6 +1101,13 @@ fn try_parsing_all_vbs_files() {
             || path
                 .to_string_lossy()
                 .contains("Tiki Bob's Atomic Beach Party Hybrid MEGA v3.vbs")
+            || path.to_string_lossy().contains("Pinball (Stern 1977).vbs")
+            || path
+                .to_string_lossy()
+                .contains("Nitro Ground Shaker (Bally 1980) 1.0.0hf5.vbs")
+            || path
+                .to_string_lossy()
+                .contains("Robo-War (Gottlieb 1988).vbs")
         {
             println!("Skipping file: !!! {}", path.display());
             continue;

--- a/testscripts/populate.sh
+++ b/testscripts/populate.sh
@@ -4,42 +4,42 @@ set -e
 # make sure we are in the correct directory
 cd "$(dirname "$0")"
 
+# Each entry is "dir url commit".
+# The commit is pinned so the test corpus is reproducible and CI is not broken by
+# upstream changes. Bump these SHAs deliberately when refreshing the corpus.
 repos=(
-  "vpx-standalone-scripts https://github.com/jsm174/vpx-standalone-scripts.git"
-  "vpinball/scripts https://github.com/vpinball/vpinball.git"
-  "sverrewl-vpxtable-scripts https://github.com/sverrewl/vpxtable_scripts.git"
-  "wine-vbscript/dlls/vbscript/tests https://github.com/wine-mirror/wine.git"
+  "vpx-standalone-scripts https://github.com/jsm174/vpx-standalone-scripts.git 15d112648a1b94b9f59eb8b3c335d57283653c50"
+  "vpinball/scripts https://github.com/vpinball/vpinball.git f40b291411cf3d31f575db8953190322c6b9ef50"
+  "sverrewl-vpxtable-scripts https://github.com/sverrewl/vpxtable_scripts.git 9e4a4a519405e14015ed009f85f34a2ecef3da38"
+  "wine-vbscript/dlls/vbscript/tests https://github.com/wine-mirror/wine.git ff95854f8cc48de0301c5e03096ad9bd7c990227"
 )
 
 for repo in "${repos[@]}"; do
-  IFS=' ' read -r -a array <<< "$repo"
-  dir=${array[0]}
-  url=${array[1]}
+  IFS=' ' read -r dir url sha <<< "$repo"
 
-  # Split the directory into repo and subdirectory
-  IFS='/' read -r -a dir_parts <<< "$dir"
-  repo_dir=${dir_parts[0]}
-  sub_dir=${dir_parts[@]:1}
-  sub_dir=$(IFS=/ ; echo "${dir_parts[*]:1}")
-
-  # If a subdirectory is provided, perform a sparse checkout of subdirectory
-  if [ -n "$sub_dir" ]; then
-    rm -rf "$repo_dir"
-    git clone -n --depth=1 --filter=tree:0 "$url" "$repo_dir"
-    cd "$repo_dir"
-    git sparse-checkout set --no-cone "$sub_dir"
-    git checkout
-    cd ..
+  # Split the directory into the clone target and an optional subdirectory, and
+  # build a sparse-checkout pattern that selects only the .vbs files we test (the
+  # `**/*.vbs` extension filter requires non-cone mode).
+  repo_dir=${dir%%/*}
+  if [ "$dir" = "$repo_dir" ]; then
+    pattern='**/*.vbs'
   else
-    if [ -d "$dir" ]; then
-      echo "Updating $dir"
-      cd "$dir"
-      git fetch origin --depth 1
-      git reset --hard origin/HEAD
-      cd ..
-    else
-      echo "Cloning $dir"
-      git clone --depth 1 "$url" "$dir"
-    fi
+    pattern="${dir#*/}/**/*.vbs"
   fi
+
+  # Skip if already checked out at the pinned commit.
+  if [ "$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null)" = "$sha" ]; then
+    echo "$repo_dir already at $sha"
+    continue
+  fi
+
+  # Sparse + `tree:0` partial + shallow so only the .vbs blobs at the pinned
+  # commit are fetched, never the whole repo (e.g. all of wine).
+  echo "Fetching $repo_dir at $sha"
+  rm -rf "$repo_dir"
+  git init -q "$repo_dir"
+  git -C "$repo_dir" remote add origin "$url"
+  git -C "$repo_dir" sparse-checkout set --no-cone "$pattern"
+  git -C "$repo_dir" fetch -q --depth 1 --filter=tree:0 origin "$sha"
+  git -C "$repo_dir" checkout -q FETCH_HEAD
 done


### PR DESCRIPTION
The integration tests download .vbs corpora from external repos at HEAD on every run, so upstream changes silently broke CI (e.g. PR #30). Pin each repo to a fixed commit in populate.sh for reproducibility.

The pinned corpus surfaced new failures, triaged against the locally built wine vbscript engine:
- Malformed (rejected by wine), excluded permanently:
  - KISS (Stern 2015): stray backtick used as a comment marker.
  - Pinball (Stern 1977) / Nitro Ground Shaker hf5: 'a..b' double dot.
  - Robo-War: SoundFX(...) call with the closing parenthesis missing.
- Valid VBScript not yet supported, skipped until the follow-up lexer fixes:
  - No Good Gofers: bracketed identifiers '[L178 Side Flasher]'.
  - wine lang.vbs: octal '&O17' and dates with day 13-31.