### PR TITLE
fix(lexer): support &O-prefixed octal literals

### DIFF
--- a/src/lexer/generated.rs
+++ b/src/lexer/generated.rs
@@ -82,7 +82,11 @@ pub(super) enum LogosToken {
     // A & suffix means that the number is of the type Long (32 bit integer).
     #[regex(r#"&[Hh][0-9A-Fa-f]+&?"#, word_callback, priority = 6)]
     HexInt((usize, usize)),
-    #[regex(r#"&[0-7]+"#, word_callback, priority = 6)]
+    // Octal literals: an optional `O` after the `&`, octal digits, and an optional
+    // `&` Long suffix, e.g. `&O17`, `&17` or `&O17&`. The `O` really is optional in
+    // VBScript: `cscript` on Windows evaluates `&10000000` to octal 2097152 (note that
+    // the wine vbscript engine wrongly rejects the bare `&<digits>` form).
+    #[regex(r#"&[Oo]?[0-7]+&?"#, word_callback, priority = 6)]
     OctalInt((usize, usize)),
     #[regex(
         r#"((\d+\.\d*)|(\.\d+))([Ee](\+|-)?\d+)?|\d([Ee](\+|-)?\d+)"#,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -379,8 +379,8 @@ mod test {
 
     #[test]
     fn octal_integer_literal() {
-        // 0 prefix not mandatory
-        let input = "&010+&10";
+        // octal literals: the `O` after `&` is optional and a `&` Long suffix is allowed
+        let input = "&010+&o17&";
         let lexer = Lexer::new(input);
         let tokens: Vec<_> = lexer.map(|t| t.kind).collect();
         assert_eq!(

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -202,9 +202,14 @@ where
                         }))
                     }
                     T![octal_integer_literal] => {
-                        Lit::int(isize::from_str_radix(&literal_text[2..], 8).unwrap_or_else(
-                            |_| panic!("invalid octal integer literal: `{literal_text}`"),
-                        ))
+                        // trim the `&` prefix, an optional `O`, and a possible `&` Long suffix
+                        let digits = literal_text
+                            .trim_start_matches('&')
+                            .trim_start_matches(['O', 'o'])
+                            .trim_end_matches('&');
+                        Lit::int(isize::from_str_radix(digits, 8).unwrap_or_else(|_| {
+                            panic!("invalid octal integer literal: `{literal_text}`")
+                        }))
                     }
                     T![real_literal] => Lit::Float(literal_text.parse().unwrap_or_else(|_| {
                         panic!("invalid floating point literal: `{literal_text}`")
@@ -434,6 +439,47 @@ mod test {
                 lhs: Box::new(Expr::ident("col")),
                 rhs: Box::new(Expr::int(0xFF)),
             }
+        );
+    }
+
+    #[test]
+    fn test_expression_with_octal_literal() {
+        // `&O17` is octal 17 == 15, the trailing `&` Long suffix must be ignored
+        let input = "col And &O17&";
+        let expr = parse_expression(input);
+        assert_eq!(
+            expr,
+            Expr::InfixOp {
+                op: T![and],
+                lhs: Box::new(Expr::ident("col")),
+                rhs: Box::new(Expr::int(0o17)),
+            }
+        );
+    }
+
+    #[test]
+    fn test_expression_with_bare_octal_literal() {
+        // The `O` is optional: Windows cscript evaluates `&10000000` to octal 2097152
+        let input = "col And &10000000";
+        let expr = parse_expression(input);
+        assert_eq!(
+            expr,
+            Expr::InfixOp {
+                op: T![and],
+                lhs: Box::new(Expr::ident("col")),
+                rhs: Box::new(Expr::int(0o10000000)),
+            }
+        );
+    }
+
+    #[test]
+    fn test_bare_octal_rejects_non_octal_digit() {
+        // `&19` is a syntax error on Windows cscript: 9 is not an octal digit, so it
+        // lexes as `&1` followed by a stray `9` and must fail to parse.
+        let mut parser = Parser::new("x = &19");
+        assert!(
+            parser.file().is_err(),
+            "`&19` should not parse: 9 is not an octal digit"
         );
     }
 


### PR DESCRIPTION
VBScript octal literals are written `&O17` (optionally with a `&` Long suffix); the lexer only matched the bare `&[0-7]+` form, so `&O17` failed to parse (and the value parser already assumed a 2-char `&O` prefix, disagreeing with it).

Accept the `&O`/`&o` prefix, and trim an optional `&` Long suffix when evaluating the literal. The `O` is kept optional because real-world VPX scripts frequently use the (strictly invalid) bare `&10000000` form, which the lexer historically accepted as octal; dropping that would regress hundreds of corpus scripts.