### PR TITLE
fix(lexer): accept day 13-31 in #M/D/YYYY# date literals

### DIFF
--- a/src/lexer/generated.rs
+++ b/src/lexer/generated.rs
@@ -95,8 +95,10 @@ pub(super) enum LogosToken {
     )]
     Float((usize, usize)),
     // TODO what is that last date format, test on windows!
+    // The day in the `#M/D/YYYY#` form is 1-2 digits (1-31); it must not be
+    // restricted to `\d[0-2]?`, which rejects days like 13-19 and 23-29.
     #[regex(
-        r#"# *\d\d?/\d[0-2]?/\d{4} *#|#\d{4}-\d[0-2]?-\d\d?#|#\d{3}-\d\d?#"#,
+        r#"# *\d\d?/\d\d?/\d{4} *#|#\d{4}-\d[0-2]?-\d\d?#|#\d{3}-\d\d?#"#,
         word_callback
     )]
     DateTime((usize, usize)),

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -776,13 +776,16 @@ mod test {
     #[test]
     fn tokenize_date_literals() {
         // Fails on windows with: runtime error: Invalid or unqualified reference
-        let input = "#1/1/2000# #12/31/2000# #1899-12-31# #112-31# # 1/1/2011 #";
+        // `#1/15/2024#` has a day (15) whose second digit is not 0-2
+        let input = "#1/1/2000# #12/31/2000# #1/15/2024# #1899-12-31# #112-31# # 1/1/2011 #";
         let mut lexer = Lexer::new(input);
         let tokens: Vec<_> = lexer.tokenize();
         let token_kinds = tokens.iter().map(|t| t.kind).collect::<Vec<_>>();
         assert_eq!(
             token_kinds,
             [
+                T![date_time_literal],
+                T![ws],
                 T![date_time_literal],
                 T![ws],
                 T![date_time_literal],

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -1052,9 +1052,6 @@ static EXCLUDED_FILES: &[&str] = &[
     "sverrewl-vpxtable-scripts/Bally Roller Derby 2.0.vbs",
     // Malformed: a stray backtick is used as a comment marker (rejected by wine vbscript).
     "vpx-standalone-scripts/KISS (Stern 2015)/KISS (Stern 2015).vbs",
-    // TODO valid VBScript, temporarily excluded until the lexer supports them:
-    // octal literals (`&O17`), wide hex (`&h000000000`) and date literals with day 13-31.
-    "wine-vbscript/dlls/vbscript/tests/lang.vbs",
 ];
 
 /// It tries to tokenize all `.vbs` files going one level lower from the root of the project.


### PR DESCRIPTION
The day field in the US-style date literal was matched with `\d[0-2]?`, which only accepts a second digit of 0-2. That rejects valid days like 15 or 27 (while 31 happened to match, as 3 is followed by 1). Match it with `\d\d?`, matching the month field. Re-enable the wine lang.vbs corpus script, which now tokenizes and parses fully (together with the &O octal fix).